### PR TITLE
アプリから施錠時の2回目のreadリクエストをなくす

### DIFF
--- a/Sources/SpacerSDK/Data/Apis/Request/Key/KeyGenerateResultReqData.swift
+++ b/Sources/SpacerSDK/Data/Apis/Request/Key/KeyGenerateResultReqData.swift
@@ -9,12 +9,10 @@ import Foundation
 
 struct KeyGenerateResultReqData: IReqData {
     var spacerId: String
-    var readData: String
 
     func toParams() -> [String: Any] {
         [
-            "spacerId": spacerId,
-            "readData": readData
+            "spacerId": spacerId
         ]
     }
 }

--- a/Sources/SpacerSDK/Data/Apis/Request/Key/KeyGetResultReqData.swift
+++ b/Sources/SpacerSDK/Data/Apis/Request/Key/KeyGetResultReqData.swift
@@ -9,12 +9,10 @@ import Foundation
 
 struct KeyGetResultReqData: IReqData {
     var spacerId: String
-    var readData: String
 
     func toParams() -> [String: Any] {
         [
-            "spacerId": spacerId,
-            "readData": readData
+            "spacerId": spacerId
         ]
     }
 }

--- a/Sources/SpacerSDK/Data/Apis/Request/Key/MaintenanceKeyGetResultReqData.swift
+++ b/Sources/SpacerSDK/Data/Apis/Request/Key/MaintenanceKeyGetResultReqData.swift
@@ -9,12 +9,10 @@ import Foundation
 
 struct MaintenanceKeyGetResultReqData: IReqData {
     var spacerId: String
-    var readData: String
 
     func toParams() -> [String: Any] {
         [
-            "spacerId": spacerId,
-            "readData": readData
+            "spacerId": spacerId
         ]
     }
 }

--- a/Sources/SpacerSDK/Data/SPRError.swift
+++ b/Sources/SpacerSDK/Data/SPRError.swift
@@ -41,7 +41,6 @@ public struct SPRError {
     static let CBConnectStartTimeout = SPRError(code: "E21011201", message: "timeout occurred while connecting to peripheral")
     static let CBConnectDiscoverTimeout = SPRError(code: "E21011202", message: "timeout occurred while discovering characteristic")
     static let CBConnectReadTimeoutBeforeWrite = SPRError(code: "E21011203", message: "timeout occurred while reading the value of the characteristic before write")
-    static let CBConnectReadTimeoutAfterWrite = SPRError(code: "E21011204", message: "timeout occurred while reading the value of the characteristic after write")
     static let CBConnectWriteTimeout = SPRError(code: "E21011205", message: "timeout occurred while writing value to characteristic")
     static let CBConnectDuringTimeout = SPRError(code: "E21011206", message: "timeout occurred during connection processing")
 }

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralMaintenanceService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralMaintenanceService.swift
@@ -39,7 +39,7 @@ extension CBLockerPeripheralMaintenanceService: CBLockerPeripheralDelegate {
     }
 
     func saveKey(locker: CBLockerModel, success: @escaping () -> Void, failure: @escaping (SPRError) -> Void) {
-        let reqData = MaintenanceKeyGetResultReqData(spacerId: locker.id, readData: locker.readData)
+        let reqData = MaintenanceKeyGetResultReqData(spacerId: locker.id)
 
         API.post(
             path: ApiPaths.MaintenanceKeyGetResult,

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralPutService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralPutService.swift
@@ -40,7 +40,7 @@ extension CBLockerPeripheralPutService: CBLockerPeripheralDelegate {
     }
 
     func saveKey(locker: CBLockerModel, success: @escaping () -> Void, failure: @escaping (SPRError) -> Void) {
-        let reqData = KeyGenerateResultReqData(spacerId: locker.id, readData: locker.readData)
+        let reqData = KeyGenerateResultReqData(spacerId: locker.id)
 
         API.post(
             path: ApiPaths.KeyGenerateResult,

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
@@ -216,12 +216,6 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
         print("peripheral didWriteValueFor")
 
         finishWritingValueToCharacteristic()
-        
-        // ↓TODO：テスト用修正のため、テスト完了後削除予定
-        if !isRetry {
-            print("書き込み後　リトライ発生")
-            return failureIfNotCanceled(SPRError.CBWritingCharacteristicFailed)
-        }
 
         guard error == nil else {
             print("peripheral didWriteValueFor failed with error: \(String(describing: error))")

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
@@ -192,12 +192,6 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
 
         finishReadingValueFromCharacteristic()
         
-        // ↓TODO：テスト用修正のため、テスト完了後削除予定
-        if !isRetry {
-            print("書き込み前　リトライ発生")
-            return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
-        }
-
         guard error == nil else {
             print("peripheral didUpdateValueFor failed with error: \(String(describing: error))")
             return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
@@ -205,6 +199,12 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
 
         guard let characteristicValue = characteristic.value else {
             print("peripheral didUpdateValueFor, characteristic value is nil")
+            return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
+        }
+        
+        // ↓TODO：テスト用修正のため、テスト完了後削除予定
+        if !isRetry {
+            print("書き込み前　リトライ発生")
             return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
         }
 

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
@@ -191,6 +191,12 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
         print("peripheral didUpdateValueFor")
 
         finishReadingValueFromCharacteristic()
+        
+        // ↓TODO：テスト用修正のため、テスト完了後削除予定
+        if !isRetry {
+            print("書き込み前　リトライ発生")
+            return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
+        }
 
         guard error == nil else {
             print("peripheral didUpdateValueFor failed with error: \(String(describing: error))")

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
@@ -89,21 +89,12 @@ class CBLockerPeripheralService: NSObject {
     }
 
     private func startReadingValueFromCharacteristic(peripheral: CBPeripheral, characteristic: CBCharacteristic) {
-        if locker.status == .none {
-            timeouts.readBeforeWrite.set()
-        } else if locker.status == .write {
-            timeouts.readAfterWrite.set()
-        }
-        
+        timeouts.readBeforeWrite.set()
         peripheral.readValue(for: characteristic)
     }
 
     private func finishReadingValueFromCharacteristic() {
-        if locker.status == .none {
-            timeouts.readBeforeWrite.clear()
-        } else if locker.status == .write {
-            timeouts.readAfterWrite.clear()
-        }
+        timeouts.readBeforeWrite.clear()
     }
 
     private func startGettingKey(peripheral: CBPeripheral, characteristic: CBCharacteristic) {
@@ -217,11 +208,7 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
         if isRetry, alreadyWrittenToCharacteristic(locker: locker) {
             startSavingKey()
         } else {
-            if locker.status == .none {
-                startGettingKey(peripheral: peripheral, characteristic: characteristic)
-            } else if locker.status == .write {
-                startSavingKey()
-            }
+            startGettingKey(peripheral: peripheral, characteristic: characteristic)
         }
     }
 
@@ -236,6 +223,6 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
         }
 
         locker.updateStatus(.write)
-        startReadingValueFromCharacteristic(peripheral: peripheral, characteristic: characteristic)
+        startSavingKey()
     }
 }

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralService.swift
@@ -201,12 +201,6 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
             print("peripheral didUpdateValueFor, characteristic value is nil")
             return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
         }
-        
-        // ↓TODO：テスト用修正のため、テスト完了後削除予定
-        if !isRetry {
-            print("書き込み前　リトライ発生")
-            return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
-        }
 
         locker.setReadData(String(bytes: characteristicValue, encoding: String.Encoding.ascii) ?? "")
         print("peripheral didUpdateValueFor, read data: \(locker.readData), status: \(locker.status)")
@@ -222,6 +216,12 @@ extension CBLockerPeripheralService: CBPeripheralDelegate {
         print("peripheral didWriteValueFor")
 
         finishWritingValueToCharacteristic()
+        
+        // ↓TODO：テスト用修正のため、テスト完了後削除予定
+        if !isRetry {
+            print("書き込み後　リトライ発生")
+            return failureIfNotCanceled(SPRError.CBWritingCharacteristicFailed)
+        }
 
         guard error == nil else {
             print("peripheral didWriteValueFor failed with error: \(String(describing: error))")

--- a/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralTakeService.swift
+++ b/Sources/SpacerSDK/Services/CBLocker/CBLockerPeripheral/CBLockerPeripheralTakeService.swift
@@ -39,7 +39,7 @@ extension CBLockerPeripheralTakeService: CBLockerPeripheralDelegate {
     }
 
     func saveKey(locker: CBLockerModel, success: @escaping () -> Void, failure: @escaping (SPRError) -> Void) {
-        let reqData = KeyGetResultReqData(spacerId: locker.id, readData: locker.readData)
+        let reqData = KeyGetResultReqData(spacerId: locker.id)
 
         API.post(
             path: ApiPaths.KeyGetResult,

--- a/Sources/SpacerSDK/Values/CBLocker/CBLockerTimeout.swift
+++ b/Sources/SpacerSDK/Values/CBLocker/CBLockerTimeout.swift
@@ -36,7 +36,6 @@ class CBLockerConnectTimeouts {
     let start: CBLockerTimeout!
     let discover: CBLockerTimeout!
     let readBeforeWrite: CBLockerTimeout!
-    let readAfterWrite: CBLockerTimeout!
     let write: CBLockerTimeout!
     let during: CBLockerTimeout!
 
@@ -44,12 +43,11 @@ class CBLockerConnectTimeouts {
         start = CBLockerTimeout(name: "start connecting", seconds: CBLockerConst.StartTimeoutSeconds, error: SPRError.CBConnectStartTimeout, executable: executable)
         discover = CBLockerTimeout(name: "discover characteristic", seconds: CBLockerConst.DiscoverTimeoutSeconds, error: SPRError.CBConnectDiscoverTimeout, executable: executable)
         readBeforeWrite = CBLockerTimeout(name: "read characteristic before write", seconds: CBLockerConst.ReadTimeoutSeconds, error: SPRError.CBConnectReadTimeoutBeforeWrite, executable: executable)
-        readAfterWrite = CBLockerTimeout(name: "read characteristic after write", seconds: CBLockerConst.ReadTimeoutSeconds, error: SPRError.CBConnectReadTimeoutAfterWrite, executable: executable)
         write = CBLockerTimeout(name: "write to characteristic", seconds: CBLockerConst.WriteTimeoutSeconds, error: SPRError.CBConnectWriteTimeout, executable: executable)
         during = CBLockerTimeout(name: "during connection processing", seconds: CBLockerConst.DuringTimeoutSeconds, error: SPRError.CBConnectDuringTimeout, executable: executable)
     }
 
     func clearAll() {
-        [start, discover, readBeforeWrite, readAfterWrite, write, during].forEach { timeout in timeout?.clear() }
+        [start, discover, readBeforeWrite, write, during].forEach { timeout in timeout?.clear() }
     }
 }


### PR DESCRIPTION
## :ticket: チケット
APL-993 [iOS SDK]アプリから施錠時の2回目のreadリクエストをなくす
https://spacer-inc.backlog.com/view/APL-993

## :memo: 概要
施錠/解錠時の筐体のステータスチェックとして行われていた2度目のreadを削除する

## :+1: 対応内容
2度目のreadを削除し、2度目のread時に行っていた処理をwrite完了時に行うように変更

## :white_check_mark: 動作確認
施錠/解錠それぞれで以下を確認　（[テストケース](https://docs.google.com/spreadsheets/d/1R_hTaP1JtkeKNHydHKQjKLjJnUNFc20WWY7fP3SAPKA/edit#gid=0)）
　・通常通り成功すること
　・書き込み前の処理で失敗時に、リトライし成功すること
　・書き込み後の処理で失敗時に、リトライし成功すること
